### PR TITLE
Fix error in computing rational Dedekind cuts

### DIFF
--- a/src/eval.ml
+++ b/src/eval.ml
@@ -202,7 +202,7 @@ struct
 		      S.Cut (x, l, q1, q2)
 		  | `equal ->
 		      (* We found an exact value *)
-		    S.Dyadic a'
+		    S.Dyadic a''
 		  | `greater ->
 		      (* We have a backwards cut. Do nothing. Someone should think
 			 whether this is ok. It would be nice if cuts could be


### PR DESCRIPTION
Before this fix, there was a bug where the identity function
```
let id = fun x : real => cut z left (z < x) right (z > x);;
```
would result in errors where `id 0` would evaluate to `-1`, `id -4` would be `-8`, `id (id -4)` would be `-16`, et cetera.

This was caused by an issue in the code for refining a Dedekind cut, where, in the case that there was an exact rational result, the computation was using a previous lower bound from an interval rather than an exact value. This one-character code modification fixes the bug!