### PR TITLE
Fix error in normalization due to lack of alpha renaming

### DIFF
--- a/src/eval.ml
+++ b/src/eval.ml
@@ -146,7 +146,9 @@ struct
 	| S.App (e1, e2)  ->
 	    let e2' = hnf env e2 in
 	      (match hnf env e1 with
-		 | S.Lambda (x, ty, e) -> hnf (Env.extend x e2' env) e
+		 | S.Lambda (x, ty, e) -> 
+                     let x',e' = alpha1 x env e in
+                     hnf (Env.extend x' e2' env) e'
 		 | e1' -> S.App (e1', e2'))
 	| S.Let (x, e1, e2) -> 
 	    let e1' = hnf env e1 in


### PR DESCRIPTION
Previously, the command
```
#hnf (fun f : (real -> prop) -> prop => fun p : real -> prop => f (fun x : real => p x)) (fun p : real -> prop => p 0);;
```
would loop, because there was an environment containing the assignment `p |-> p`, and then we added an assignment `p |-> fun x : real => p x`, where the `p` in the body of that would refer to the new `p`, whereas it should have referred to the old `p`. With the alpha renaming, we now instead add the assignment `p' |-> fun x : real => p x`, and replace every `p` with `p'` in the lambda expression that we are substituting in to.

Now, the above command no longer loops, instead evaluating to the correct answer.