### PR TITLE
Fix rounding error in interval power computation

### DIFF
--- a/src/interval.ml
+++ b/src/interval.ml
@@ -179,7 +179,7 @@ struct
 		    lpow a k
 	    ) ;
 	    upper = lazy (
-	      let upow = D.pow ~prec ~round in
+	      let upow = D.pow ~prec ~round:dnuor in
 		if D.negative a then
 		  if D.negative b then
 		    upow a k


### PR DESCRIPTION
When we compute an upper bound for interval computation, if the rounding mode is down, we want to round our answer up (and if the rounding mode is up, we want to round our answer down).

An example of fixing broken behavior:
We will try to compute `1.41421356237309504^2`. All examples use `bignum` for dyadic computations.
Correct answer (from Wolfram Alpha):
```
1.9999999999999999751050648688726016
```
Previous returned answer (default precision):
```
# 1.41421356237309504^2;;
- : real = 1.99999999953 +- 0.e-11
```
Note that it estimates that there is no error whatsoever, and that the estimate is below the true answer.
New answer:
```
# 1.41421356237309504^2;;
- : real = 1.9999999999999999594170 +- 1.36e-20
```