### PR TITLE
Fix Newton approximation rounding the wrong way

### DIFF
--- a/src/newton.ml
+++ b/src/newton.ml
@@ -99,17 +99,17 @@ struct
     | S.App (e1, e2) -> failwith "Cannot differentiate a redex"
 
   
-  let estimate_endpoint prec x y d =            
+  let estimate_endpoint prec round x y d =            
         match D.sgn d with
   	| `negative ->
-  	    let b' = D.sub ~prec ~round:D.down x (D.div ~prec ~round:D.up y d) in  	      
+  	    let b' = D.sub ~prec ~round x (D.div ~prec ~round:(D.anti round) y d) in  	      
   		R.open_left_ray b'
   	| `zero ->
   	    (match D.sgn y with
   	       | `negative | `zero -> R.empty
   	       | `positive -> R.real_line)
   	| `positive ->
-  	    let a' = D.sub ~prec ~round:D.up x (D.div ~prec ~round:D.down y d) in  	     
+  	    let a' = D.sub ~prec ~round:(D.anti round) x (D.div ~prec ~round y d) in  	     
   		R.open_right_ray a'
 
   (* The function [estimate_positive env x i e] returns a set such that
@@ -132,8 +132,8 @@ struct
       let y2 = I.lower (A.get_interval (A.lower prec (Env.extend x (S.Dyadic x2) env) e)) in 
       let lif = A.get_interval (A.lower prec (Env.extend x (S.Interval i) env) (diff x e)) in  (* Lifschitz constant as an interval *)      	
 	(R.union
-	  (estimate_endpoint prec x1 y1 (I.lower lif)) (* estimate at i.lower *)
-	  (estimate_endpoint prec x2 y2 (I.upper lif)))  (* estimate at i.upper*)
+	  (estimate_endpoint prec D.down x1 y1 (I.lower lif)) (* estimate at i.lower *)
+	  (estimate_endpoint prec D.down x2 y2 (I.upper lif)))  (* estimate at i.upper*)
 
   (* The function [estimate_non_positive env x i e] returns a
      set such that in environment [env] the expression [e] with
@@ -155,8 +155,8 @@ struct
       let y2 = I.lower (A.get_interval (A.upper prec (Env.extend x (S.Dyadic x2) env) e)) in 
       let lif = A.get_interval (A.upper prec (Env.extend x (S.Interval (I.flip i)) env) (diff x e)) in  (* Lifschitz constant as an interval *)                 
       if not (I.proper (I.flip lif)) then R.real_line else
-	  R.union (estimate_endpoint prec x1 y1 (I.lower lif))
-		 (estimate_endpoint prec x2 y2 (I.upper lif))
+	  R.union (estimate_endpoint prec D.up x1 y1 (I.lower lif))
+		 (estimate_endpoint prec D.up x2 y2 (I.upper lif))
 	
 
   (* The function [estimate prec env i x p] returns a pair of sets [(a,b)]


### PR DESCRIPTION
The estimation of where an expression is nonpositive was rounding the wrong way for doing the linear projection in the Newton approximation.

Previously, in computing the square root of 2, we would get the wrong answer, and the answer would indicate that the answer was actually rational:
```
# cut x left x < 0 \/ x * x < 2 right x > 0 /\ 2 < x * x;;
- : real = 1.41421356237309504880168866
```

Now, the answer is this:
```
# cut x left x < 0 \/ x * x < 2 right x > 0 /\ 2 < x * x;;
- : real = 1.41421356237309504880168887 +- 4.1e-25
```
Which seems to be correct, checking the square of the endpoints with Wolfram Alpha.